### PR TITLE
support the tracking of a list of events

### DIFF
--- a/lib/segment/analytics.ex
+++ b/lib/segment/analytics.ex
@@ -4,6 +4,17 @@ defmodule Segment.Analytics do
 
   require Logger
 
+  def batch_track(events) when is_list(events) do
+    %Segment.Analytics.BatchTrack{
+      batch: Enum.map(events, fn e -> valid_track_event(e) end)
+    }
+    |> call
+  end
+
+  defp valid_track_event(t = %Segment.Analytics.Track{}) do
+    t
+  end
+
   def track(t = %Segment.Analytics.Track{}) do
     call(t)
   end

--- a/lib/segment/analytics.ex
+++ b/lib/segment/analytics.ex
@@ -11,8 +11,8 @@ defmodule Segment.Analytics do
     |> call
   end
 
-  defp valid_track_event(t = %Segment.Analytics.Track{}) do
-    t
+  defp valid_track_event(track = %Segment.Analytics.Track{}) do
+    track
   end
 
   def track(t = %Segment.Analytics.Track{}) do

--- a/lib/segment/model.ex
+++ b/lib/segment/model.ex
@@ -1,3 +1,13 @@
+defmodule Segment.Analytics.BatchTrack do
+  @derive {Poison.Encoder, except: [:method]}
+  @method "track"
+
+  defstruct [
+    :batch,
+    method: @method
+  ]
+end
+
 defmodule Segment.Analytics.Track do
   @derive [Poison.Encoder]
   @method "track"

--- a/test/segment/analytics_test.exs
+++ b/test/segment/analytics_test.exs
@@ -1,4 +1,6 @@
 defmodule Segment.Analytics.AnalyticsTest do
+  # not used in async mode because of Bypass
+  # test fail randomly
   use ExUnit.Case
 
   setup do

--- a/test/segment/analytics_test.exs
+++ b/test/segment/analytics_test.exs
@@ -1,0 +1,51 @@
+defmodule Segment.Analytics.AnalyticsTest do
+  use ExUnit.Case
+
+  setup do
+    bypass = Bypass.open()
+    Segment.start_link("123", endpoint_url(bypass.port))
+
+    {:ok, bypass: bypass}
+  end
+
+  describe "batch_track/1" do
+    test "send a batch event", %{bypass: bypass} do
+      Bypass.expect(bypass, fn conn ->
+        body = ~s"""
+        {
+          "batch":[
+            {
+              "userId":null,
+              "timestamp":null,
+              "properties":{},
+              "method":"track",
+              "integrations":null,
+              "event":"test1",
+              "context":{},
+              "anonymousId":null
+            }
+          ]
+        }
+        """
+
+        assert {:ok, body, _conn} = Plug.Conn.read_body(conn)
+
+        Plug.Conn.resp(conn, 200, "")
+      end)
+
+      events = [
+        %Segment.Analytics.Track{
+          userId: nil,
+          event: "test1",
+          properties: %{},
+          context: %{}
+        }
+      ]
+
+      task = Segment.Analytics.batch_track(events)
+      Task.await(task)
+    end
+  end
+
+  defp endpoint_url(port), do: "http://localhost:#{port}/"
+end

--- a/test/segment/http_test.exs
+++ b/test/segment/http_test.exs
@@ -1,5 +1,5 @@
 defmodule Segment.Analytics.HttpTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   @apikey "afakekey"
   @url "something"

--- a/test/segment/http_test.exs
+++ b/test/segment/http_test.exs
@@ -1,4 +1,6 @@
 defmodule Segment.Analytics.HttpTest do
+  # not used in async mode because of Bypass
+  # test fail randomly
   use ExUnit.Case
 
   @apikey "afakekey"


### PR DESCRIPTION
the custom segment server requires to send a batch of events.
In this PR we just support the format but we dont implement any batching mechanism which is, therefore, delegated to the consumer of the application for the time being.