### PR TITLE
Allow endpoint and api key to be passed via options to the new public

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ analytics-elixir is a non-supported third-party client for [Segment](https://seg
 
 ## Install
 
-Add the following to deps section of your mix.exs: `{:segment, github: "stueccles/analytics-elixir"}`
+Add the following to deps section of your mix.exs: `{:segment, github: "FindHotel/analytics-elixir"}`
 
 and then `mix deps.get`
 
@@ -24,7 +24,7 @@ with all the data for the API (allowing Context and Integrations to be set)
 
 This is how I add to a Phoenix project (may not be your preferred way)
 
-1. Add the following to deps section of your mix.exs: `{:segment, github: "stueccles/analytics-elixir"}`
+1. Add the following to deps section of your mix.exs: `{:segment, github: "FindHotel/analytics-elixir"}`
    and then `mix deps.get`
 
 2. Add segment to applications list in the Phoenix project mix.exs
@@ -124,6 +124,20 @@ or the full way using a struct with all the possible options for the page call
                        }
   |> Segment.Analytics.page
 ```
+
+### Config as options
+
+You can also pass the __endpoint__ and __key__ as options to the
+`Segment.Analytics.call/2` along with the struct.
+```
+%Segment.Analytics.Track{ userId: "sdsds",
+                          event: "eventname",
+                          properties: %{property1: "", property2: ""}
+                        }
+  |> Segment.Analytics.call([key: "YOUR_SEGMENT_KEY", endpoint: "https://example.com/v1"])
+```
+
+With this approach the options take precedence over configurations stored in the Segment agent.
 
 ## Running tests
 

--- a/lib/segment/analytics.ex
+++ b/lib/segment/analytics.ex
@@ -74,7 +74,7 @@ defmodule Segment.Analytics do
     |> call
   end
 
-  defp call(model) do
+  def call(model, options \\ []) do
     batch =
       model
       |> generate_message_id()
@@ -82,7 +82,7 @@ defmodule Segment.Analytics do
       |> wrap_in_batch()
       |> Poison.encode!()
 
-    Task.async(fn -> post_to_segment(batch) end)
+    Task.async(fn -> post_to_segment(batch, options) end)
   end
 
   # TODO: replace with an actual buffering
@@ -103,8 +103,8 @@ defmodule Segment.Analytics do
     put_in(model.messageId, UUID.uuid4())
   end
 
-  defp post_to_segment(body) do
-    Http.post("", body)
+  defp post_to_segment(body, options) do
+    Http.post("", body, options)
     |> log_result(body)
   end
 

--- a/lib/segment/http.ex
+++ b/lib/segment/http.ex
@@ -1,14 +1,21 @@
 defmodule Segment.Analytics.Http do
-  use HTTPoison.Base
-
-  def process_url(url) do
-    Segment.endpoint() <> url
+  def post(path, body, options) do
+    path
+    |> process_url(options)
+    |> HTTPoison.post(body, process_request_headers(options))
   end
 
-  def process_request_headers(headers) do
-    headers
-    |> Keyword.put(:"Content-Type", "application/json")
-    |> Keyword.put(:accept, "application/json")
-    |> Keyword.put(:"x-api-key", Segment.key())
+  def process_url(path, options),
+    do: get_config(options, :endpoint, &Segment.endpoint/0) <> path
+
+  def process_request_headers(options) do
+    [
+      {"Content-Type", "application/json"},
+      {"Accept", "application/json"},
+      {"x-api-key", get_config(options, :key, &Segment.key/0)}
+    ]
   end
+
+  def get_config(options, key, default_func),
+    do: Keyword.get(options, key) || default_func.()
 end

--- a/test/segment/analytics_test.exs
+++ b/test/segment/analytics_test.exs
@@ -5,13 +5,13 @@ defmodule Segment.Analytics.AnalyticsTest do
 
   setup do
     bypass = Bypass.open()
-    Segment.start_link("123", endpoint_url(bypass.port))
+    start_supervised({Segment, [key: "123", endpoint: endpoint_url(bypass.port)]})
 
     {:ok, bypass: bypass}
   end
 
   describe "track/1" do
-    test "send a track event", %{bypass: bypass} do
+    test "sends a track event", %{bypass: bypass} do
       Bypass.expect(bypass, fn conn ->
         {:ok, received_body, _conn} = Plug.Conn.read_body(conn)
 
@@ -63,6 +63,128 @@ defmodule Segment.Analytics.AnalyticsTest do
       }
 
       task = Segment.Analytics.track(event)
+      Task.await(task)
+    end
+  end
+
+  describe "call/2" do
+    test "sends an event", %{bypass: bypass} do
+      Bypass.expect(bypass, fn conn ->
+        {:ok, received_body, _conn} = Plug.Conn.read_body(conn)
+
+        assert %{
+                 "batch" => [
+                   %{
+                     "userId" => nil,
+                     "type" => "track",
+                     "timestamp" => nil,
+                     "properties" => %{},
+                     "integrations" => nil,
+                     "event" => "test1",
+                     "context" => %{
+                       "userAgent" => nil,
+                       "traits" => nil,
+                       "timezone" => nil,
+                       "screen" => nil,
+                       "referrer" => nil,
+                       "page" => nil,
+                       "os" => nil,
+                       "network" => nil,
+                       "location" => nil,
+                       "locale" => nil,
+                       "library" => %{
+                         "version" => "0.1.2",
+                         "transport" => "http",
+                         "name" => "analytics_elixir"
+                       },
+                       "ip" => nil,
+                       "device" => nil,
+                       "campaign" => nil,
+                       "app" => nil
+                     },
+                     "anonymousId" => nil
+                   }
+                 ]
+               } = Poison.decode!(received_body)
+
+        # messageId and sentAt are not asserted
+
+        Plug.Conn.resp(conn, 200, "")
+      end)
+
+      event = %Segment.Analytics.Track{
+        userId: nil,
+        event: "test1",
+        properties: %{},
+        context: %Segment.Analytics.Context{}
+      }
+
+      task = Segment.Analytics.call(event)
+      Task.await(task)
+    end
+
+    test "sends an event using endpoint and key from options", %{bypass: bypass} do
+      Bypass.expect(bypass, fn _conn ->
+        flunk("#{endpoint_url(bypass.port)} shouldn't be called")
+      end)
+
+      Bypass.pass(bypass)
+
+      another_bypass = Bypass.open()
+
+      Bypass.expect(another_bypass, fn conn ->
+        {:ok, received_body, _conn} = Plug.Conn.read_body(conn)
+
+        assert %{
+                 "batch" => [
+                   %{
+                     "userId" => nil,
+                     "type" => "track",
+                     "timestamp" => nil,
+                     "properties" => %{},
+                     "integrations" => nil,
+                     "event" => "test1",
+                     "context" => %{
+                       "userAgent" => nil,
+                       "traits" => nil,
+                       "timezone" => nil,
+                       "screen" => nil,
+                       "referrer" => nil,
+                       "page" => nil,
+                       "os" => nil,
+                       "network" => nil,
+                       "location" => nil,
+                       "locale" => nil,
+                       "library" => %{
+                         "version" => "0.1.2",
+                         "transport" => "http",
+                         "name" => "analytics_elixir"
+                       },
+                       "ip" => nil,
+                       "device" => nil,
+                       "campaign" => nil,
+                       "app" => nil
+                     },
+                     "anonymousId" => nil
+                   }
+                 ]
+               } = Poison.decode!(received_body)
+
+        # messageId and sentAt are not asserted
+
+        Plug.Conn.resp(conn, 200, "")
+      end)
+
+      event = %Segment.Analytics.Track{
+        userId: nil,
+        event: "test1",
+        properties: %{},
+        context: %Segment.Analytics.Context{}
+      }
+
+      options = [key: "anotherkey", endpoint: endpoint_url(another_bypass.port)]
+
+      task = Segment.Analytics.call(event, options)
       Task.await(task)
     end
   end

--- a/test/segment_test.exs
+++ b/test/segment_test.exs
@@ -5,9 +5,40 @@ defmodule SegmentTest do
 
   @segment_test_key System.get_env("SEGMENT_KEY")
 
-  test "track debugging" do
-    Segment.start_link(@segment_test_key, "https://api.segment.io/v1/track")
+  setup do
+    {:ok, config: [key: @segment_test_key, endpoint: "https://api.segment.io/v1/track"]}
+  end
+
+  test "tracks debugging", %{config: config} do
+    start_supervised!({Segment, config})
+
     t = Segment.Analytics.track("343434", "track debugging #{elem(:os.timestamp(), 2)}")
     Task.await(t)
+  end
+
+  describe "key/0" do
+    test "returns segment key", %{config: config} do
+      start_supervised!({Segment, config})
+
+      assert Segment.key() == Keyword.get(config, :key)
+    end
+
+    test "when agent was not started, raises an error" do
+      assert {:noproc, {GenServer, :call, [Segment, {:get, _function}, 5000]}} =
+               catch_exit(Segment.key())
+    end
+  end
+
+  describe "endpoint/0" do
+    test "returns segment endpoint", %{config: config} do
+      start_supervised!({Segment, config})
+
+      assert Segment.endpoint() == Keyword.get(config, :endpoint)
+    end
+
+    test "when agent was not started, returns nil" do
+      assert {:noproc, {GenServer, :call, [Segment, {:get, _function}, 5000]}} =
+               catch_exit(Segment.endpoint())
+    end
   end
 end


### PR DESCRIPTION
Allow endpoint and api key to be passed via options to the new public.